### PR TITLE
Add royality patch soo champions use composite armor. (AKA armor that acually blocks bullets)

### DIFF
--- a/Patches/Pawnkinds_Empire.xml
+++ b/Patches/Pawnkinds_Empire.xml
@@ -7,46 +7,13 @@
 		</mods>
 		<match Class="PatchOperationSequence">	
 		<operations>
-
-            <!--Trooper-->
-            <li Class="PatchOperationReplace">
-                <xpath>Defs/PawnKindDef[@Name ="ImperialTrooperBase"]/apparelRequired</xpath>
-                <value>
-                    <apparelRequired>
-                        <li>Apparel_AdvancedHelmet</li>
-						<li>CE_Armor_BallisticGoggles</li>
-                        <li>CE_Armor_FragSuit</li>
-                        <li>CE_Apparel_CompositeVest</li>
-                        <li>Apparel_Backpack</li>
-						<li>CE_Apparel_TacVest</li>
-                        <li>CE_Armor_Balaclava</li>
-                    </apparelRequired>
-                </value>
-            </li>
-
-            <li Class="PatchOperationReplace" MayRequire="ceteam.combatextendedarmors">
-                <xpath>Defs/PawnKindDef[@Name ="ImperialTrooperBase"]/apparelRequired</xpath>
-                <value>
-                    <apparelRequired>
-                        <li>Apparel_AdvancedHelmet</li>
-						<li>CE_Armor_BallisticGoggles</li>
-                        <li>CE_Armor_FragSuit</li>
-                        <li>CE_Apparel_CompositeVest</li>
-                        <li>CE_Armor_LargeBackpack</li>
-						<li>CE_Apparel_TacVest</li>
-                        <li>CE_Armor_Balaclava</li>
-                    </apparelRequired>
-                </value>
-            </li>
-
+		
             <!--Champion-->
             <li Class="PatchOperationReplace">
                 <xpath>Defs/PawnKindDef[defName ="Empire_Fighter_Champion"]/apparelRequired</xpath>
                 <value>
                     <apparelRequired>
                         <li>Apparel_AdvancedHelmet</li>
-						<li>CE_Armor_BallisticGoggles</li>
-						<li>CE_Armor_Jumpsuit</li>
                         <li>CE_Apparel_CompositeArmor</li>
                         <li>Apparel_ShieldBelt</li>
                     </apparelRequired>

--- a/Patches/Pawnkinds_Empire.xml
+++ b/Patches/Pawnkinds_Empire.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+    
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Royalty</li>
+		</mods>
+		<match Class="PatchOperationSequence">	
+		<operations>
+
+            <!--Trooper-->
+            <li Class="PatchOperationReplace">
+                <xpath>Defs/PawnKindDef[@Name ="ImperialTrooperBase"]/apparelRequired</xpath>
+                <value>
+                    <apparelRequired>
+                        <li>Apparel_AdvancedHelmet</li>
+						<li>CE_Armor_BallisticGoggles</li>
+                        <li>CE_Armor_FragSuit</li>
+                        <li>CE_Apparel_CompositeVest</li>
+                        <li>Apparel_Backpack</li>
+						<li>CE_Apparel_TacVest</li>
+                        <li>CE_Armor_Balaclava</li>
+                    </apparelRequired>
+                </value>
+            </li>
+
+            <li Class="PatchOperationReplace" MayRequire="ceteam.combatextendedarmors">
+                <xpath>Defs/PawnKindDef[@Name ="ImperialTrooperBase"]/apparelRequired</xpath>
+                <value>
+                    <apparelRequired>
+                        <li>Apparel_AdvancedHelmet</li>
+						<li>CE_Armor_BallisticGoggles</li>
+                        <li>CE_Armor_FragSuit</li>
+                        <li>CE_Apparel_CompositeVest</li>
+                        <li>CE_Armor_LargeBackpack</li>
+						<li>CE_Apparel_TacVest</li>
+                        <li>CE_Armor_Balaclava</li>
+                    </apparelRequired>
+                </value>
+            </li>
+
+            <!--Champion-->
+            <li Class="PatchOperationReplace">
+                <xpath>Defs/PawnKindDef[defName ="Empire_Fighter_Champion"]/apparelRequired</xpath>
+                <value>
+                    <apparelRequired>
+                        <li>Apparel_AdvancedHelmet</li>
+						<li>CE_Armor_BallisticGoggles</li>
+						<li>CE_Armor_Jumpsuit</li>
+                        <li>CE_Apparel_CompositeArmor</li>
+                        <li>Apparel_ShieldBelt</li>
+                    </apparelRequired>
+                </value>
+            </li>
+
+		</operations>
+        </match>
+    </Operation>    
+</Patch> 


### PR DESCRIPTION
Plate armor just isnt good enough for emperial champions imo, and since this mod adds industrial alternative to it, they should use it.
And since the armor from this mod is really similar (if not the exact same) to armor from CE armors expanded cut. I copied some code from it, and trimmed it soo it uses only things from vanilla and this mod. Its a simple patch and it works without errors for me.