### PR TITLE
Fix KS-23's recoil value

### DIFF
--- a/1.4/Defs/ThingDefs/Weapons_CEA_Guns/KS-23.xml
+++ b/1.4/Defs/ThingDefs/Weapons_CEA_Guns/KS-23.xml
@@ -37,7 +37,7 @@
         <defaultProjectile>Bullet_23x75mmR_Buck</defaultProjectile>
         <warmupTime>0.6</warmupTime>
         <range>20</range>
-        <soundCast>Shot_Shotgun_NoRack</soundCast>
+        <soundCast>Shot_Shotgun</soundCast>
         <soundCastTail>GunTail_Heavy</soundCastTail>
         <muzzleFlashScale>9</muzzleFlashScale>
       </li>

--- a/1.4/Defs/ThingDefs/Weapons_CEA_Guns/KS-23.xml
+++ b/1.4/Defs/ThingDefs/Weapons_CEA_Guns/KS-23.xml
@@ -31,7 +31,7 @@
     </costList>
     <verbs>
       <li Class="CombatExtended.VerbPropertiesCE">
-        <recoilAmount>4.70</recoilAmount>
+        <recoilAmount>3.89</recoilAmount>
         <verbClass>CombatExtended.Verb_ShootCE</verbClass>
         <hasStandardCommand>true</hasStandardCommand>
         <defaultProjectile>Bullet_23x75mmR_Buck</defaultProjectile>


### PR DESCRIPTION
What it says on the tin, it was based on the old 23mm shells.