### PR TITLE
Weapon stat update/fix

### DIFF
--- a/1.4/Defs/ThingDefs/Weapons_CEA_Guns/M250.xml
+++ b/1.4/Defs/ThingDefs/Weapons_CEA_Guns/M250.xml
@@ -16,26 +16,26 @@
       <li>RangedHeavy</li>
     </weaponClasses>
     <statBases>
-      <WorkToMake>50500</WorkToMake>
+      <WorkToMake>46000</WorkToMake>
       <SightsEfficiency>1.1</SightsEfficiency>
-      <ShotSpread>0.06</ShotSpread>
-      <SwayFactor>1.51</SwayFactor>
-      <Bulk>12.00</Bulk>
+      <ShotSpread>0.08</ShotSpread>
+      <SwayFactor>1.21</SwayFactor>
+      <Bulk>12.13</Bulk>
       <Mass>6.6</Mass>
       <RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
     </statBases>
     <costList>
-      <Steel>75</Steel>
+      <Steel>70</Steel>
       <ComponentIndustrial>7</ComponentIndustrial>
-      <Chemfuel>20</Chemfuel>
+      <Chemfuel>10</Chemfuel>
     </costList>
     <verbs>
       <li Class="CombatExtended.VerbPropertiesCE">
-        <recoilAmount>1.4</recoilAmount>
+        <recoilAmount>1.52</recoilAmount>
         <verbClass>CombatExtended.Verb_ShootCE</verbClass>
         <hasStandardCommand>true</hasStandardCommand>
         <defaultProjectile>Bullet_277Fury_FMJ</defaultProjectile>
-        <warmupTime>1.1</warmupTime>
+        <warmupTime>1.2</warmupTime>
         <range>65</range>
         <ticksBetweenBurstShots>6</ticksBetweenBurstShots>
         <burstShotCount>10</burstShotCount>

--- a/1.4/Defs/ThingDefs/Weapons_CEA_Guns/M7.xml
+++ b/1.4/Defs/ThingDefs/Weapons_CEA_Guns/M7.xml
@@ -13,26 +13,26 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <statBases>
-      <WorkToMake>39000</WorkToMake>
+      <WorkToMake>36000</WorkToMake>
       <SightsEfficiency>1.1</SightsEfficiency>
-      <ShotSpread>0.04</ShotSpread>
-      <SwayFactor>1.50</SwayFactor>
-      <Bulk>10.50</Bulk>
+      <ShotSpread>0.11</ShotSpread>
+      <SwayFactor>1.36</SwayFactor>
+      <Bulk>7.65</Bulk>
       <Mass>4.46</Mass>
       <RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
     </statBases>
     <costList>
-      <Steel>55</Steel>
+      <Steel>50</Steel>
       <ComponentIndustrial>6</ComponentIndustrial>
-      <Chemfuel>15</Chemfuel>
+      <Chemfuel>5</Chemfuel>
     </costList>
-    <weaponTags Inherit="False">
+    <weaponTags>
       <li>CE_AI_AR</li>
       <li>IndustrialGunAdvanced</li>
     </weaponTags>
     <verbs>
       <li Class="CombatExtended.VerbPropertiesCE">
-        <recoilAmount>1.9</recoilAmount>
+        <recoilAmount>1.89</recoilAmount>
         <verbClass>CombatExtended.Verb_ShootCE</verbClass>
         <hasStandardCommand>true</hasStandardCommand>
         <defaultProjectile>Bullet_277Fury_FMJ</defaultProjectile>

--- a/1.4/Defs/ThingDefs/Weapons_CEA_Guns/MG338.xml
+++ b/1.4/Defs/ThingDefs/Weapons_CEA_Guns/MG338.xml
@@ -5,7 +5,7 @@
 
   <ThingDef ParentName="BaseHumanMakeableGun">
     <defName>CE_Gun_MGThreeThreeEight</defName>
-    <label>SIG MG338</label>
+    <label>MG 338</label>
     <description>Ancient lightweight medium machine gun. The MG 338 is designed to bridge the gap between light machine gun and heavy machine gun calibers making use of a bigger cartridge while being lighter than other machine gun designs.</description>
     <graphicData>
       <texPath>Things/Weapons/MG338</texPath>
@@ -16,22 +16,22 @@
       <li>RangedHeavy</li>
     </weaponClasses>
     <statBases>
-      <WorkToMake>56500</WorkToMake>
+      <WorkToMake>48000</WorkToMake>
       <SightsEfficiency>1.1</SightsEfficiency>
-      <ShotSpread>0.06</ShotSpread>
-      <SwayFactor>1.51</SwayFactor>
-      <Bulk>14.00</Bulk>
-      <Mass>9.5</Mass>
+      <ShotSpread>0.03</ShotSpread>
+      <SwayFactor>1.57</SwayFactor>
+      <Bulk>13.7</Bulk>
+      <Mass>9.7</Mass>
       <RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
     </statBases>
     <costList>
-      <Steel>95</Steel>
+      <Steel>85</Steel>
       <ComponentIndustrial>7</ComponentIndustrial>
-      <Chemfuel>20</Chemfuel>
+      <Chemfuel>10</Chemfuel>
     </costList>
     <verbs>
       <li Class="CombatExtended.VerbPropertiesCE">
-        <recoilAmount>1.8</recoilAmount>
+        <recoilAmount>1.78</recoilAmount>
         <verbClass>CombatExtended.Verb_ShootCE</verbClass>
         <hasStandardCommand>true</hasStandardCommand>
         <defaultProjectile>Bullet_338Norma_FMJ</defaultProjectile>


### PR DESCRIPTION
The M7, M250 and MG 338 has incorrect stats that are fixed in this PR.
(The work cost of the three guns should be lower than this but they are artificially increased to simulate them being more advanced.)