### PR TITLE
Shotgun turret fire rate tweak

### DIFF
--- a/1.4/Defs/ThingDefs/Emplacements_CEA/ShotgunTurret.xml
+++ b/1.4/Defs/ThingDefs/Emplacements_CEA/ShotgunTurret.xml
@@ -24,7 +24,7 @@
         <verbClass>CombatExtended.Verb_ShootCE</verbClass>
         <hasStandardCommand>true</hasStandardCommand>
         <defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
-        <warmupTime>0.8</warmupTime>
+        <warmupTime>0.6</warmupTime>  <!-- Lowered manually from 0.8 due to how slow the turret is. -->
         <range>16</range>
         <soundCast>Shot_Shotgun_NoRack</soundCast>
         <soundCastTail>GunTail_Medium</soundCastTail>

--- a/1.4/Defs/ThingDefs/Emplacements_CEA/ShotgunTurret.xml
+++ b/1.4/Defs/ThingDefs/Emplacements_CEA/ShotgunTurret.xml
@@ -70,6 +70,7 @@
     <building>
       <ai_combatDangerous>true</ai_combatDangerous>
       <turretGunDef>Gun_ShotgunTurret</turretGunDef>
+      <turretBurstCooldownTime>0.5</turretBurstCooldownTime>
     </building>
     <placeWorkers>
       <li>PlaceWorker_TurretTop</li>


### PR DESCRIPTION
Lowered the shotgun turret's warmup time from 0.8 to 0.6 due to how slow the turret is when firing in aimed shot mode.
Also lowered its turret cooldown time from the base 1s to 0.5 due to how it's a semi-auto turret and does not need the high cooldown time.