### PR TITLE
Composite helmet tweaks and fixes

### DIFF
--- a/1.4/Defs/ThingDefs/Apparel_CEA/HeavyCompositeHelmet.xml
+++ b/1.4/Defs/ThingDefs/Apparel_CEA/HeavyCompositeHelmet.xml
@@ -10,6 +10,7 @@
     <graphicData>
       <texPath>Things/Apparel/HeavyCompositeHelmet/HeavyCompositeHelmet</texPath>
       <graphicClass>Graphic_Single</graphicClass>
+      <drawSize>0.7</drawSize>
     </graphicData>
     <techLevel>Industrial</techLevel>
     <generateCommonality>0.2</generateCommonality>

--- a/1.4/Defs/ThingDefs/Apparel_CEA/HeavyCompositeHelmet.xml
+++ b/1.4/Defs/ThingDefs/Apparel_CEA/HeavyCompositeHelmet.xml
@@ -46,7 +46,6 @@
     </thingCategories>
     <apparel>
       <wornGraphicPath>Things/Apparel/HeavyCompositeHelmet/HeavyCompositeHelmet</wornGraphicPath>
-      <useWornGraphicMask>true</useWornGraphicMask>
       <bodyPartGroups>
         <li>FullHead</li>
       </bodyPartGroups>


### PR DESCRIPTION
Tweaked the size of the heavy composite helmet so that it's not huge when places on the ground.
Removed a redundant node that was stopping the helmet from being dyed.