### PR TITLE
Kord weaponTag tweaks

### DIFF
--- a/1.4/Defs/ThingDefs/Weapons_CEA_Guns/Kord.xml
+++ b/1.4/Defs/ThingDefs/Weapons_CEA_Guns/Kord.xml
@@ -65,8 +65,6 @@
       <li>RewardStandardQualitySuper</li>
     </thingSetMakerTags>
     <weaponTags>
-      <li>IndustrialGunAdvanced</li>
-      <li>CE_MachineGun</li>
       <li>CE_AI_LMG</li>
       <li>Bipod_ATR</li>
     </weaponTags>


### PR DESCRIPTION
Removed the weapon tags from the Kord MG as none of the vanilla and DLC pawnKinds can reliably carry it without inventory issues, it's too heavy.