### PR TITLE
Minor recipe inheritance fix

### DIFF
--- a/1.4/Defs/ThingDefs/Weapons_CEA_Guns/HandMortar.xml
+++ b/1.4/Defs/ThingDefs/Weapons_CEA_Guns/HandMortar.xml
@@ -66,7 +66,7 @@
 			</li>
 		</comps>
 		<recipeMaker>
-			<recipeUsers>
+			<recipeUsers Inherit="False">
 				<li>FueledSmithy</li>
 				<li>ElectricSmithy</li>
 			</recipeUsers>

--- a/1.4/Defs/ThingDefs/Weapons_CEA_Guns/WallGun.xml
+++ b/1.4/Defs/ThingDefs/Weapons_CEA_Guns/WallGun.xml
@@ -61,7 +61,7 @@
 			</li>
 		</comps>
 		<recipeMaker>
-			<recipeUsers>
+			<recipeUsers Inherit="False">
 				<li>FueledSmithy</li>
 				<li>ElectricSmithy</li>
 			</recipeUsers>


### PR DESCRIPTION
## Changes

- Fixed the inheritance issue on the wall gun and hand mortar, both were showing up in the machining bench as well as the smithy by mistake.