### PR TITLE
Weapon research prerequisite housekeeping

### DIFF
--- a/1.4/Defs/ThingDefs/Weapons_CEA_Guns/M250.xml
+++ b/1.4/Defs/ThingDefs/Weapons_CEA_Guns/M250.xml
@@ -70,7 +70,11 @@
 			<li>Bipod_LMG</li>
 		</weaponTags>
 		<recipeMaker>
-			<researchPrerequisite>PrecisionRifling</researchPrerequisite>
+			<researchPrerequisite Inherit="false" />
+			<researchPrerequisites>
+				<li>PrecisionRifling</li>
+				<li>CE_SimpleNV</li>
+			</researchPrerequisites>
 			<skillRequirements>
 				<Crafting>7</Crafting>
 			</skillRequirements>

--- a/1.4/Defs/ThingDefs/Weapons_CEA_Guns/M7.xml
+++ b/1.4/Defs/ThingDefs/Weapons_CEA_Guns/M7.xml
@@ -61,7 +61,11 @@
 			</li>
 		</comps>
 		<recipeMaker>
-			<researchPrerequisite>PrecisionRifling</researchPrerequisite>
+			<researchPrerequisite Inherit="false" />
+			<researchPrerequisites>
+				<li>PrecisionRifling</li>
+				<li>CE_SimpleNV</li>
+			</researchPrerequisites>
 			<skillRequirements>
 				<Crafting>7</Crafting>
 			</skillRequirements>

--- a/1.4/Defs/ThingDefs/Weapons_CEA_Guns/MG338.xml
+++ b/1.4/Defs/ThingDefs/Weapons_CEA_Guns/MG338.xml
@@ -70,7 +70,11 @@
 			<li>Bipod_LMG</li>
 		</weaponTags>
 		<recipeMaker>
-			<researchPrerequisite>PrecisionRifling</researchPrerequisite>
+			<researchPrerequisite Inherit="false" />
+			<researchPrerequisites>
+				<li>PrecisionRifling</li>
+				<li>CE_SimpleNV</li>
+			</researchPrerequisites>
 			<skillRequirements>
 				<Crafting>7</Crafting>
 			</skillRequirements>


### PR DESCRIPTION
## Changes

- Made the M7, M250 and MG338 correctly require the basic optics research project as well as precision rifling.
