### PR TITLE
Add supportsWallAttachments to Reinforced Walls

### DIFF
--- a/1.5/Defs/ThingDefs/Structures_CEA/Walls.xml
+++ b/1.5/Defs/ThingDefs/Structures_CEA/Walls.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+			<?xml version="1.0" encoding="utf-8"?>
 <Defs>
 
 	<ThingDef ParentName="BuildingBase" Name="CE_ReinforcedWall">
@@ -62,6 +62,7 @@
 			<Steel>10</Steel>
 		</costList>
 		<building>
+			<supportsWallAttachments>true</supportsWallAttachments>
 			<paintable>true</paintable>
 			<isInert>true</isInert>
 			<ai_chillDestination>false</ai_chillDestination>

--- a/1.5/Defs/ThingDefs/Structures_CEA/Walls.xml
+++ b/1.5/Defs/ThingDefs/Structures_CEA/Walls.xml
@@ -1,4 +1,4 @@
-			<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Defs>
 
 	<ThingDef ParentName="BuildingBase" Name="CE_ReinforcedWall">


### PR DESCRIPTION
## Additions

Adds the ability to add wall lights to reinforced walls.

## Changes

Changes reinforced walls to support attachments.

## References

None

## Reasoning

Reinforced walls should be able to support wall lights.

## Alternatives

None considered.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [X] Game runs without errors
- [X] Playtested a colony (specify how long) - long enough to test that wall lights can now be attached
