### PR TITLE
Lewis Gun range tweak

### DIFF
--- a/1.4/Defs/ThingDefs/Weapons_CEA_Guns/Lewis.xml
+++ b/1.4/Defs/ThingDefs/Weapons_CEA_Guns/Lewis.xml
@@ -37,7 +37,7 @@
 				<hasStandardCommand>true</hasStandardCommand>
 				<defaultProjectile>Bullet_3006Springfield_FMJ</defaultProjectile>
 				<warmupTime>1.3</warmupTime>
-				<range>75</range>
+				<range>68</range>
 				<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
 				<burstShotCount>10</burstShotCount>
 				<soundCast>Shot_CE_BattleRifle</soundCast>

--- a/1.5/Defs/ThingDefs/Weapons_CEA_Guns/Lewis.xml
+++ b/1.5/Defs/ThingDefs/Weapons_CEA_Guns/Lewis.xml
@@ -37,7 +37,7 @@
 				<hasStandardCommand>true</hasStandardCommand>
 				<defaultProjectile>Bullet_3006Springfield_FMJ</defaultProjectile>
 				<warmupTime>1.3</warmupTime>
-				<range>75</range>
+				<range>68</range>
 				<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
 				<burstShotCount>10</burstShotCount>
 				<soundCast>Shot_CE_BattleRifle</soundCast>


### PR DESCRIPTION
Dropped the Lewis Gun's range from 800 to 700 meters, 75 to 68 tiles, balance reasons.