### PR TITLE
TAC-50 Bipod tag fix

### DIFF
--- a/1.4/Defs/ThingDefs/Weapons_CEA_Guns/TAC-50.xml
+++ b/1.4/Defs/ThingDefs/Weapons_CEA_Guns/TAC-50.xml
@@ -60,7 +60,7 @@
 		</thingSetMakerTags>
 		<weaponTags Inherit="False">
 			<li>SniperRifle</li>
-			<li>Bipod_DMR</li>
+			<li>Bipod_AMR</li>
 			<li>CE_AI_SR</li>
 		</weaponTags>
 		<recipeMaker>

--- a/1.5/Defs/ThingDefs/Weapons_CEA_Guns/TAC-50.xml
+++ b/1.5/Defs/ThingDefs/Weapons_CEA_Guns/TAC-50.xml
@@ -60,7 +60,7 @@
 		</thingSetMakerTags>
 		<weaponTags Inherit="False">
 			<li>SniperRifle</li>
-			<li>Bipod_DMR</li>
+			<li>Bipod_AMR</li>
 			<li>CE_AI_SR</li>
 		</weaponTags>
 		<recipeMaker>


### PR DESCRIPTION
## Changes

- Fixed the bipod tag, was set to DMR by mistake, it's an AMR. CE didn't have AMR bipods when the gun was removed from the CE Guns.