### PR TITLE
Fixed wall lamp attachment to reinforced wall

### DIFF
--- a/1.5/Defs/ThingDefs/Structures_CEA/Walls.xml
+++ b/1.5/Defs/ThingDefs/Structures_CEA/Walls.xml
@@ -66,6 +66,7 @@
 			<paintable>true</paintable>
 			<isInert>true</isInert>
 			<ai_chillDestination>false</ai_chillDestination>
+			<supportsWallAttachments>true</supportsWallAttachments>
 			<blueprintGraphicData>
 				<texPath>Things/Building/Linked/Wall_Blueprint_Atlas</texPath>
 			</blueprintGraphicData>


### PR DESCRIPTION
Simply added supportsWallAttachments attribute to reinforced walls and set it to true.