### PR TITLE
CE prefix for the emplacements

### DIFF
--- a/1.4/Defs/ThingDefs/Emplacements_CEA/12Pounder.xml
+++ b/1.4/Defs/ThingDefs/Emplacements_CEA/12Pounder.xml
@@ -4,7 +4,7 @@
 	<!-- ==================== 12 Pounder Cannon ==================== -->
 
 	<ThingDef ParentName="BaseTurretGun">
-		<defName>Gun_TwelvePounder</defName>
+		<defName>CE_Gun_TwelvePounder</defName>
 		<label>12-pounder cannon</label>
 		<graphicData>
 			<texPath>Things/Building/Security/12Pounder/12Pounder_gun</texPath>
@@ -50,7 +50,7 @@
 	</ThingDef>
 
 	<ThingDef ParentName="TurretMannedBuildableBase">
-		<defName>Turret_TwelvePounder</defName>
+		<defName>CE_Turret_TwelvePounder</defName>
 		<label>12-pounder cannon</label>
 		<constructionSkillPrerequisite>6</constructionSkillPrerequisite>
 		<graphicData>
@@ -74,7 +74,7 @@
 			<WoodLog>150</WoodLog>
 		</costList>
 		<building>
-			<turretGunDef>Gun_TwelvePounder</turretGunDef>
+			<turretGunDef>CE_Gun_TwelvePounder</turretGunDef>
 			<ai_combatDangerous>true</ai_combatDangerous>
 			<turretBurstCooldownTime>2.5</turretBurstCooldownTime>
 		</building>

--- a/1.4/Defs/ThingDefs/Emplacements_CEA/12PounderBombard.xml
+++ b/1.4/Defs/ThingDefs/Emplacements_CEA/12PounderBombard.xml
@@ -4,7 +4,7 @@
 	<!-- ==================== 12 Pounder Bombard ==================== -->
 
 	<ThingDef ParentName="BaseArtilleryWeapon">
-		<defName>Gun_12PounderBombard</defName>
+		<defName>CE_Gun_12PounderBombard</defName>
 		<label>12-pounder bombard</label>
 		<graphicData>
 			<texPath>Things/Building/Security/12PounderBombard/12PounderBombard_turret</texPath>
@@ -59,7 +59,7 @@
 	</ThingDef>
 
 	<ThingDef ParentName="BaseArtilleryBuilding">
-		<defName>Turret_12PounderBombard</defName>
+		<defName>CE_Turret_12PounderBombard</defName>
 		<label>12-pounder bombard</label>
 		<description>12-pounder siege mortar mounted on a carriage.</description>
 		<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
@@ -85,7 +85,7 @@
 			<WoodLog>150</WoodLog>
 		</costList>
 		<building>
-			<turretGunDef>Gun_12PounderBombard</turretGunDef>
+			<turretGunDef>CE_Gun_12PounderBombard</turretGunDef>
 			<ai_combatDangerous>true</ai_combatDangerous>
 			<turretBurstCooldownTime>2.0</turretBurstCooldownTime>
 			<spawnedConceptLearnOpportunity>CE_MortarDirectFire</spawnedConceptLearnOpportunity>

--- a/1.4/Defs/ThingDefs/Emplacements_CEA/GatlingGun.xml
+++ b/1.4/Defs/ThingDefs/Emplacements_CEA/GatlingGun.xml
@@ -4,7 +4,7 @@
 	<!-- ==================== Gatling Gun ==================== -->
 
 	<ThingDef ParentName="BaseTurretGun">
-		<defName>Gun_GatlingGun</defName>
+		<defName>CE_Gun_GatlingGun</defName>
 		<label>Gatling gun</label>
 		<graphicData>
 			<texPath>Things/Building/Security/GatlingGun/GatlingGun_gun</texPath>
@@ -51,7 +51,7 @@
 	</ThingDef>
 
 	<ThingDef ParentName="TurretMannedBuildableBase">
-		<defName>Turret_GatlingGun</defName>
+		<defName>CE_Turret_GatlingGun</defName>
 		<label>Gatling gun</label>
 		<constructionSkillPrerequisite>6</constructionSkillPrerequisite>
 		<graphicData>
@@ -75,7 +75,7 @@
 			<ComponentIndustrial>3</ComponentIndustrial>
 		</costList>
 		<building>
-			<turretGunDef>Gun_GatlingGun</turretGunDef>
+			<turretGunDef>CE_Gun_GatlingGun</turretGunDef>
 			<ai_combatDangerous>true</ai_combatDangerous>
 			<turretBurstCooldownTime>0.36</turretBurstCooldownTime>
 		</building>

--- a/1.4/Defs/ThingDefs/Emplacements_CEA/M1919.xml
+++ b/1.4/Defs/ThingDefs/Emplacements_CEA/M1919.xml
@@ -4,7 +4,7 @@
 	<!-- ==================== M1919 ==================== -->
 
 	<ThingDef ParentName="BaseTurretGun">
-		<defName>Gun_M1919Browning</defName>
+		<defName>CE_Gun_M1919Browning</defName>
 		<label>M1919 machine gun</label>
 		<graphicData>
 			<texPath>Things/Building/Security/M1919/M1919_gun</texPath>
@@ -51,7 +51,7 @@
 	</ThingDef>
 
 	<ThingDef ParentName="TurretMannedBuildableBase">
-		<defName>Turret_M1919Browning</defName>
+		<defName>CE_Turret_M1919Browning</defName>
 		<label>M1919 machine gun</label>
 		<constructionSkillPrerequisite>6</constructionSkillPrerequisite>
 		<graphicData>
@@ -74,7 +74,7 @@
 			<ComponentIndustrial>6</ComponentIndustrial>
 		</costList>
 		<building>
-			<turretGunDef>Gun_M1919Browning</turretGunDef>
+			<turretGunDef>CE_Gun_M1919Browning</turretGunDef>
 			<ai_combatDangerous>true</ai_combatDangerous>
 			<turretBurstCooldownTime>0.36</turretBurstCooldownTime>
 		</building>

--- a/1.4/Defs/ThingDefs/Emplacements_CEA/M2HB.xml
+++ b/1.4/Defs/ThingDefs/Emplacements_CEA/M2HB.xml
@@ -4,7 +4,7 @@
 	<!-- ==================== M2HB ==================== -->
 
 	<ThingDef ParentName="BaseTurretGun">
-		<defName>Gun_M2HB</defName>
+		<defName>CE_Gun_M2HB</defName>
 		<label>M2 Browning machine gun</label>
 		<graphicData>
 			<texPath>Things/Building/Security/M2HB/M2HB_gun</texPath>
@@ -51,7 +51,7 @@
 	</ThingDef>
 
 	<ThingDef ParentName="TurretMannedBuildableBase">
-		<defName>Turret_M2HB</defName>
+		<defName>CE_Turret_M2HB</defName>
 		<label>M2 Browning machine gun</label>
 		<constructionSkillPrerequisite>7</constructionSkillPrerequisite>
 		<graphicData>
@@ -75,7 +75,7 @@
 			<ComponentIndustrial>6</ComponentIndustrial>
 		</costList>
 		<building>
-			<turretGunDef>Gun_M2HB</turretGunDef>
+			<turretGunDef>CE_Gun_M2HB</turretGunDef>
 			<ai_combatDangerous>true</ai_combatDangerous>
 			<turretBurstCooldownTime>0.36</turretBurstCooldownTime>
 		</building>

--- a/1.4/Defs/ThingDefs/Emplacements_CEA/Mk-19.xml
+++ b/1.4/Defs/ThingDefs/Emplacements_CEA/Mk-19.xml
@@ -4,7 +4,7 @@
 	<!-- ==================== Mk-19 ==================== -->
 
 	<ThingDef ParentName="BaseTurretGun">
-		<defName>Gun_MkNineteenGL</defName>
+		<defName>CE_Gun_MkNineteenGL</defName>
 		<label>Mk 19 grenade launcher</label>
 		<graphicData>
 			<texPath>Things/Building/Security/Mk19/Mk19_gun</texPath>
@@ -54,7 +54,7 @@
 	</ThingDef>
 
 	<ThingDef ParentName="TurretMannedBuildableBase">
-		<defName>Turret_MkNineteenGL</defName>
+		<defName>CE_Turret_MkNineteenGL</defName>
 		<label>Mk 19 grenade launcher</label>
 		<constructionSkillPrerequisite>6</constructionSkillPrerequisite>
 		<graphicData>
@@ -77,7 +77,7 @@
 			<ComponentIndustrial>5</ComponentIndustrial>
 		</costList>
 		<building>
-			<turretGunDef>Gun_MkNineteenGL</turretGunDef>
+			<turretGunDef>CE_Gun_MkNineteenGL</turretGunDef>
 			<ai_combatDangerous>true</ai_combatDangerous>
 			<turretBurstCooldownTime>0.40</turretBurstCooldownTime>
 		</building>

--- a/1.4/Defs/ThingDefs/Emplacements_CEA/OrganGun.xml
+++ b/1.4/Defs/ThingDefs/Emplacements_CEA/OrganGun.xml
@@ -4,7 +4,7 @@
 	<!-- ==================== Organ Gun ==================== -->
 
 	<ThingDef ParentName="BaseTurretGun">
-		<defName>Gun_OrganGun</defName>
+		<defName>CE_Gun_OrganGun</defName>
 		<label>organ gun</label>
 		<graphicData>
 			<texPath>Things/Building/Security/OrganGun/OrganGun_gun</texPath>
@@ -53,7 +53,7 @@
 	</ThingDef>
 
 	<ThingDef ParentName="TurretMannedBuildableBase">
-		<defName>Turret_OrganGun</defName>
+		<defName>CE_Turret_OrganGun</defName>
 		<label>organ gun</label>
 		<constructionSkillPrerequisite>6</constructionSkillPrerequisite>
 		<graphicData>
@@ -77,7 +77,7 @@
 			<WoodLog>80</WoodLog>
 		</costList>
 		<building>
-			<turretGunDef>Gun_OrganGun</turretGunDef>
+			<turretGunDef>CE_Gun_OrganGun</turretGunDef>
 			<ai_combatDangerous>true</ai_combatDangerous>
 			<turretBurstCooldownTime>1.0</turretBurstCooldownTime>
 		</building>

--- a/1.4/Defs/ThingDefs/Emplacements_CEA/PKM.xml
+++ b/1.4/Defs/ThingDefs/Emplacements_CEA/PKM.xml
@@ -4,7 +4,7 @@
 	<!-- ==================== PKM ==================== -->
 
 	<ThingDef ParentName="BaseTurretGun">
-		<defName>Gun_PKM</defName>
+		<defName>CE_Gun_PKM</defName>
 		<label>PKM machine gun</label>
 		<graphicData>
 			<texPath>Things/Building/Security/PKM/PKM_gun</texPath>
@@ -51,7 +51,7 @@
 	</ThingDef>
 
 	<ThingDef ParentName="TurretMannedBuildableBase">
-		<defName>Turret_PKM</defName>
+		<defName>CE_Turret_PKM</defName>
 		<label>PKM machine gun</label>
 		<constructionSkillPrerequisite>6</constructionSkillPrerequisite>
 		<graphicData>
@@ -74,7 +74,7 @@
 			<ComponentIndustrial>6</ComponentIndustrial>
 		</costList>
 		<building>
-			<turretGunDef>Gun_PKM</turretGunDef>
+			<turretGunDef>CE_Gun_PKM</turretGunDef>
 			<ai_combatDangerous>true</ai_combatDangerous>
 			<turretBurstCooldownTime>0.36</turretBurstCooldownTime>
 		</building>

--- a/1.4/Defs/ThingDefs/Emplacements_CEA/PortableMortar.xml
+++ b/1.4/Defs/ThingDefs/Emplacements_CEA/PortableMortar.xml
@@ -4,7 +4,7 @@
 	<!-- ==================== 60mm Mortar ==================== -->
 
 	<ThingDef ParentName="BaseArtilleryWeapon">
-		<defName>Gun_PortabletMortar</defName>
+		<defName>CE_Gun_PortabletMortar</defName>
 		<label>60mm mortar</label>
 		<graphicData>
 			<texPath>Things/Building/Security/PortableMortar/PortableMortar_turret</texPath>
@@ -58,7 +58,7 @@
 	</ThingDef>
 
 	<ThingDef ParentName="BaseArtilleryBuilding">
-		<defName>Turret_PortableMortar</defName>
+		<defName>CE_Turret_PortableMortar</defName>
 		<label>60mm portable mortar</label>
 		<description>A compact small caliber field mortar for indirect fire at medium ranges.</description>
 		<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
@@ -97,7 +97,7 @@
 			<li>CE_Turret</li>
 		</tradeTags>
 		<building>
-			<turretGunDef>Gun_PortabletMortar</turretGunDef>
+			<turretGunDef>CE_Gun_PortabletMortar</turretGunDef>
 			<ai_combatDangerous>true</ai_combatDangerous>
 			<turretBurstCooldownTime>2.0</turretBurstCooldownTime>
 			<spawnedConceptLearnOpportunity>CE_MortarDirectFire</spawnedConceptLearnOpportunity>

--- a/1.4/Defs/ThingDefs/Emplacements_CEA/SPG-9.xml
+++ b/1.4/Defs/ThingDefs/Emplacements_CEA/SPG-9.xml
@@ -4,7 +4,7 @@
 	<!-- ==================== SPG-9 ==================== -->
 
 	<ThingDef ParentName="BaseTurretGun">
-		<defName>Gun_SPGNine</defName>
+		<defName>CE_Gun_SPGNine</defName>
 		<label>SPG-9 recoilless gun</label>
 		<description>SPG-9 recoilless gun mounted on a tripod.</description>
 		<graphicData>
@@ -50,7 +50,7 @@
 	</ThingDef>
 
 	<ThingDef ParentName="TurretMannedBuildableBase">
-		<defName>Turret_SPGNine</defName>
+		<defName>CE_Turret_SPGNine</defName>
 		<label>SPG-9 recoilless gun</label>
 		<constructionSkillPrerequisite>8</constructionSkillPrerequisite>
 		<graphicData>
@@ -73,7 +73,7 @@
 			<ComponentIndustrial>5</ComponentIndustrial>
 		</costList>
 		<building>
-			<turretGunDef>Gun_SPGNine</turretGunDef>
+			<turretGunDef>CE_Gun_SPGNine</turretGunDef>
 			<ai_combatDangerous>true</ai_combatDangerous>
 			<turretBurstCooldownTime>1.5</turretBurstCooldownTime>
 		</building>

--- a/1.4/Defs/ThingDefs/Emplacements_CEA/ShotgunTurret.xml
+++ b/1.4/Defs/ThingDefs/Emplacements_CEA/ShotgunTurret.xml
@@ -4,7 +4,7 @@
 	<!-- ==================== Shotgun Turret ==================== -->
 
 	<ThingDef ParentName="BaseAutoTurretGun">
-		<defName>Gun_ShotgunTurret</defName>
+		<defName>CE_Gun_ShotgunTurret</defName>
 		<label>shotgun auto-turret gun</label>
 		<graphicData>
 			<texPath>Things/Building/Security/ShotgunTurret/ShotgunTurret_gun</texPath>
@@ -42,7 +42,7 @@
 	</ThingDef>
 
 	<ThingDef ParentName="TurretAutoBase">
-		<defName>Turret_ShotgunTurret</defName>
+		<defName>CE_Turret_ShotgunTurret</defName>
 		<label>shotgun auto-turret</label>
 		<constructionSkillPrerequisite>5</constructionSkillPrerequisite>
 		<graphicData>
@@ -69,7 +69,7 @@
 		</costList>
 		<building>
 			<ai_combatDangerous>true</ai_combatDangerous>
-			<turretGunDef>Gun_ShotgunTurret</turretGunDef>
+			<turretGunDef>CE_Gun_ShotgunTurret</turretGunDef>
 			<turretBurstCooldownTime>0.5</turretBurstCooldownTime>
 		</building>
 		<placeWorkers>

--- a/1.4/Defs/ThingDefs/Emplacements_CEA/Vickers.xml
+++ b/1.4/Defs/ThingDefs/Emplacements_CEA/Vickers.xml
@@ -4,7 +4,7 @@
 	<!-- ==================== Vickers ==================== -->
 
 	<ThingDef ParentName="BaseTurretGun">
-		<defName>Gun_Vickers</defName>
+		<defName>CE_Gun_Vickers</defName>
 		<label>Vickers machine gun</label>
 		<graphicData>
 			<texPath>Things/Building/Security/Vickers/Vickers_gun</texPath>
@@ -51,7 +51,7 @@
 	</ThingDef>
 
 	<ThingDef ParentName="TurretMannedBuildableBase">
-		<defName>Turret_Vickers</defName>
+		<defName>CE_Turret_Vickers</defName>
 		<label>Vickers machine gun</label>
 		<constructionSkillPrerequisite>6</constructionSkillPrerequisite>
 		<graphicData>
@@ -74,7 +74,7 @@
 			<ComponentIndustrial>5</ComponentIndustrial>
 		</costList>
 		<building>
-			<turretGunDef>Gun_Vickers</turretGunDef>
+			<turretGunDef>CE_Gun_Vickers</turretGunDef>
 			<ai_combatDangerous>true</ai_combatDangerous>
 			<turretBurstCooldownTime>0.36</turretBurstCooldownTime>
 		</building>

--- a/1.5/Defs/ThingDefs/Emplacements_CEA/12Pounder.xml
+++ b/1.5/Defs/ThingDefs/Emplacements_CEA/12Pounder.xml
@@ -4,7 +4,7 @@
 	<!-- ==================== 12 Pounder Cannon ==================== -->
 
 	<ThingDef ParentName="BaseTurretGun">
-		<defName>Gun_TwelvePounder</defName>
+		<defName>CE_Gun_TwelvePounder</defName>
 		<label>12-pounder cannon</label>
 		<graphicData>
 			<texPath>Things/Building/Security/12Pounder/12Pounder_gun</texPath>
@@ -51,7 +51,7 @@
 	</ThingDef>
 
 	<ThingDef ParentName="TurretMannedBuildableBase">
-		<defName>Turret_TwelvePounder</defName>
+		<defName>CE_Turret_TwelvePounder</defName>
 		<label>12-pounder cannon</label>
 		<constructionSkillPrerequisite>6</constructionSkillPrerequisite>
 		<graphicData>
@@ -75,7 +75,7 @@
 			<WoodLog>150</WoodLog>
 		</costList>
 		<building>
-			<turretGunDef>Gun_TwelvePounder</turretGunDef>
+			<turretGunDef>CE_Gun_TwelvePounder</turretGunDef>
 			<ai_combatDangerous>true</ai_combatDangerous>
 			<turretBurstCooldownTime>2.5</turretBurstCooldownTime>
 		</building>

--- a/1.5/Defs/ThingDefs/Emplacements_CEA/12PounderBombard.xml
+++ b/1.5/Defs/ThingDefs/Emplacements_CEA/12PounderBombard.xml
@@ -4,7 +4,7 @@
 	<!-- ==================== 12 Pounder Bombard ==================== -->
 
 	<ThingDef ParentName="BaseArtilleryWeapon">
-		<defName>Gun_12PounderBombard</defName>
+		<defName>CE_Gun_12PounderBombard</defName>
 		<label>12-pounder bombard</label>
 		<graphicData>
 			<texPath>Things/Building/Security/12PounderBombard/12PounderBombard_turret</texPath>
@@ -59,7 +59,7 @@
 	</ThingDef>
 
 	<ThingDef ParentName="BaseArtilleryBuilding">
-		<defName>Turret_12PounderBombard</defName>
+		<defName>CE_Turret_12PounderBombard</defName>
 		<label>12-pounder bombard</label>
 		<description>12-pounder siege mortar mounted on a carriage.</description>
 		<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
@@ -85,7 +85,7 @@
 			<WoodLog>150</WoodLog>
 		</costList>
 		<building>
-			<turretGunDef>Gun_12PounderBombard</turretGunDef>
+			<turretGunDef>CE_Gun_12PounderBombard</turretGunDef>
 			<ai_combatDangerous>true</ai_combatDangerous>
 			<turretBurstCooldownTime>2.0</turretBurstCooldownTime>
 			<spawnedConceptLearnOpportunity>CE_MortarDirectFire</spawnedConceptLearnOpportunity>

--- a/1.5/Defs/ThingDefs/Emplacements_CEA/GatlingGun.xml
+++ b/1.5/Defs/ThingDefs/Emplacements_CEA/GatlingGun.xml
@@ -4,7 +4,7 @@
 	<!-- ==================== Gatling Gun ==================== -->
 
 	<ThingDef ParentName="BaseTurretGun">
-		<defName>Gun_GatlingGun</defName>
+		<defName>CE_Gun_GatlingGun</defName>
 		<label>Gatling gun</label>
 		<graphicData>
 			<texPath>Things/Building/Security/GatlingGun/GatlingGun_gun</texPath>
@@ -51,7 +51,7 @@
 	</ThingDef>
 
 	<ThingDef ParentName="TurretMannedBuildableBase">
-		<defName>Turret_GatlingGun</defName>
+		<defName>CE_Turret_GatlingGun</defName>
 		<label>Gatling gun</label>
 		<constructionSkillPrerequisite>6</constructionSkillPrerequisite>
 		<graphicData>
@@ -75,7 +75,7 @@
 			<ComponentIndustrial>3</ComponentIndustrial>
 		</costList>
 		<building>
-			<turretGunDef>Gun_GatlingGun</turretGunDef>
+			<turretGunDef>CE_Gun_GatlingGun</turretGunDef>
 			<ai_combatDangerous>true</ai_combatDangerous>
 			<turretBurstCooldownTime>0.36</turretBurstCooldownTime>
 		</building>

--- a/1.5/Defs/ThingDefs/Emplacements_CEA/M1919.xml
+++ b/1.5/Defs/ThingDefs/Emplacements_CEA/M1919.xml
@@ -4,7 +4,7 @@
 	<!-- ==================== M1919 ==================== -->
 
 	<ThingDef ParentName="BaseTurretGun">
-		<defName>Gun_M1919Browning</defName>
+		<defName>CE_Gun_M1919Browning</defName>
 		<label>M1919 machine gun</label>
 		<graphicData>
 			<texPath>Things/Building/Security/M1919/M1919_gun</texPath>
@@ -51,7 +51,7 @@
 	</ThingDef>
 
 	<ThingDef ParentName="TurretMannedBuildableBase">
-		<defName>Turret_M1919Browning</defName>
+		<defName>CE_Turret_M1919Browning</defName>
 		<label>M1919 machine gun</label>
 		<constructionSkillPrerequisite>6</constructionSkillPrerequisite>
 		<graphicData>
@@ -74,7 +74,7 @@
 			<ComponentIndustrial>6</ComponentIndustrial>
 		</costList>
 		<building>
-			<turretGunDef>Gun_M1919Browning</turretGunDef>
+			<turretGunDef>CE_Gun_M1919Browning</turretGunDef>
 			<ai_combatDangerous>true</ai_combatDangerous>
 			<turretBurstCooldownTime>0.36</turretBurstCooldownTime>
 		</building>

--- a/1.5/Defs/ThingDefs/Emplacements_CEA/M2HB.xml
+++ b/1.5/Defs/ThingDefs/Emplacements_CEA/M2HB.xml
@@ -4,7 +4,7 @@
 	<!-- ==================== M2HB ==================== -->
 
 	<ThingDef ParentName="BaseTurretGun">
-		<defName>Gun_M2HB</defName>
+		<defName>CE_Gun_M2HB</defName>
 		<label>M2 Browning machine gun</label>
 		<graphicData>
 			<texPath>Things/Building/Security/M2HB/M2HB_gun</texPath>
@@ -51,7 +51,7 @@
 	</ThingDef>
 
 	<ThingDef ParentName="TurretMannedBuildableBase">
-		<defName>Turret_M2HB</defName>
+		<defName>CE_Turret_M2HB</defName>
 		<label>M2 Browning machine gun</label>
 		<constructionSkillPrerequisite>7</constructionSkillPrerequisite>
 		<graphicData>
@@ -75,7 +75,7 @@
 			<ComponentIndustrial>6</ComponentIndustrial>
 		</costList>
 		<building>
-			<turretGunDef>Gun_M2HB</turretGunDef>
+			<turretGunDef>CE_Gun_M2HB</turretGunDef>
 			<ai_combatDangerous>true</ai_combatDangerous>
 			<turretBurstCooldownTime>0.36</turretBurstCooldownTime>
 		</building>

--- a/1.5/Defs/ThingDefs/Emplacements_CEA/Mk-19.xml
+++ b/1.5/Defs/ThingDefs/Emplacements_CEA/Mk-19.xml
@@ -4,7 +4,7 @@
 	<!-- ==================== Mk-19 ==================== -->
 
 	<ThingDef ParentName="BaseTurretGun">
-		<defName>Gun_MkNineteenGL</defName>
+		<defName>CE_Gun_MkNineteenGL</defName>
 		<label>Mk 19 grenade launcher</label>
 		<graphicData>
 			<texPath>Things/Building/Security/Mk19/Mk19_gun</texPath>
@@ -54,7 +54,7 @@
 	</ThingDef>
 
 	<ThingDef ParentName="TurretMannedBuildableBase">
-		<defName>Turret_MkNineteenGL</defName>
+		<defName>CE_Turret_MkNineteenGL</defName>
 		<label>Mk 19 grenade launcher</label>
 		<constructionSkillPrerequisite>6</constructionSkillPrerequisite>
 		<graphicData>
@@ -77,7 +77,7 @@
 			<ComponentIndustrial>5</ComponentIndustrial>
 		</costList>
 		<building>
-			<turretGunDef>Gun_MkNineteenGL</turretGunDef>
+			<turretGunDef>CE_Gun_MkNineteenGL</turretGunDef>
 			<ai_combatDangerous>true</ai_combatDangerous>
 			<turretBurstCooldownTime>0.40</turretBurstCooldownTime>
 		</building>

--- a/1.5/Defs/ThingDefs/Emplacements_CEA/OrganGun.xml
+++ b/1.5/Defs/ThingDefs/Emplacements_CEA/OrganGun.xml
@@ -4,7 +4,7 @@
 	<!-- ==================== Organ Gun ==================== -->
 
 	<ThingDef ParentName="BaseTurretGun">
-		<defName>Gun_OrganGun</defName>
+		<defName>CE_Gun_OrganGun</defName>
 		<label>organ gun</label>
 		<graphicData>
 			<texPath>Things/Building/Security/OrganGun/OrganGun_gun</texPath>
@@ -54,7 +54,7 @@
 	</ThingDef>
 
 	<ThingDef ParentName="TurretMannedBuildableBase">
-		<defName>Turret_OrganGun</defName>
+		<defName>CE_Turret_OrganGun</defName>
 		<label>organ gun</label>
 		<constructionSkillPrerequisite>6</constructionSkillPrerequisite>
 		<graphicData>
@@ -78,7 +78,7 @@
 			<WoodLog>80</WoodLog>
 		</costList>
 		<building>
-			<turretGunDef>Gun_OrganGun</turretGunDef>
+			<turretGunDef>CE_Gun_OrganGun</turretGunDef>
 			<ai_combatDangerous>true</ai_combatDangerous>
 			<turretBurstCooldownTime>1.0</turretBurstCooldownTime>
 		</building>

--- a/1.5/Defs/ThingDefs/Emplacements_CEA/PKM.xml
+++ b/1.5/Defs/ThingDefs/Emplacements_CEA/PKM.xml
@@ -4,7 +4,7 @@
 	<!-- ==================== PKM ==================== -->
 
 	<ThingDef ParentName="BaseTurretGun">
-		<defName>Gun_PKM</defName>
+		<defName>CE_Gun_PKM</defName>
 		<label>PKM machine gun</label>
 		<graphicData>
 			<texPath>Things/Building/Security/PKM/PKM_gun</texPath>
@@ -51,7 +51,7 @@
 	</ThingDef>
 
 	<ThingDef ParentName="TurretMannedBuildableBase">
-		<defName>Turret_PKM</defName>
+		<defName>CE_Turret_PKM</defName>
 		<label>PKM machine gun</label>
 		<constructionSkillPrerequisite>6</constructionSkillPrerequisite>
 		<graphicData>
@@ -74,7 +74,7 @@
 			<ComponentIndustrial>6</ComponentIndustrial>
 		</costList>
 		<building>
-			<turretGunDef>Gun_PKM</turretGunDef>
+			<turretGunDef>CE_Gun_PKM</turretGunDef>
 			<ai_combatDangerous>true</ai_combatDangerous>
 			<turretBurstCooldownTime>0.36</turretBurstCooldownTime>
 		</building>

--- a/1.5/Defs/ThingDefs/Emplacements_CEA/PortableMortar.xml
+++ b/1.5/Defs/ThingDefs/Emplacements_CEA/PortableMortar.xml
@@ -4,7 +4,7 @@
 	<!-- ==================== 60mm Mortar ==================== -->
 
 	<ThingDef ParentName="BaseArtilleryWeapon">
-		<defName>Gun_PortabletMortar</defName>
+		<defName>CE_Gun_PortabletMortar</defName>
 		<label>60mm mortar</label>
 		<graphicData>
 			<texPath>Things/Building/Security/PortableMortar/PortableMortar_turret</texPath>
@@ -58,7 +58,7 @@
 	</ThingDef>
 
 	<ThingDef ParentName="BaseArtilleryBuilding">
-		<defName>Turret_PortableMortar</defName>
+		<defName>CE_Turret_PortableMortar</defName>
 		<label>60mm portable mortar</label>
 		<description>A compact small caliber field mortar for indirect fire at medium ranges.</description>
 		<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
@@ -97,7 +97,7 @@
 			<li>CE_Turret</li>
 		</tradeTags>
 		<building>
-			<turretGunDef>Gun_PortabletMortar</turretGunDef>
+			<turretGunDef>CE_Gun_PortabletMortar</turretGunDef>
 			<ai_combatDangerous>true</ai_combatDangerous>
 			<turretBurstCooldownTime>2.0</turretBurstCooldownTime>
 			<spawnedConceptLearnOpportunity>CE_MortarDirectFire</spawnedConceptLearnOpportunity>

--- a/1.5/Defs/ThingDefs/Emplacements_CEA/SPG-9.xml
+++ b/1.5/Defs/ThingDefs/Emplacements_CEA/SPG-9.xml
@@ -4,7 +4,7 @@
 	<!-- ==================== SPG-9 ==================== -->
 
 	<ThingDef ParentName="BaseTurretGun">
-		<defName>Gun_SPGNine</defName>
+		<defName>CE_Gun_SPGNine</defName>
 		<label>SPG-9 recoilless gun</label>
 		<description>SPG-9 recoilless gun mounted on a tripod.</description>
 		<soundInteract>Artillery_ShellLoaded</soundInteract>
@@ -51,7 +51,7 @@
 	</ThingDef>
 
 	<ThingDef ParentName="TurretMannedBuildableBase">
-		<defName>Turret_SPGNine</defName>
+		<defName>CE_Turret_SPGNine</defName>
 		<label>SPG-9 recoilless gun</label>
 		<constructionSkillPrerequisite>8</constructionSkillPrerequisite>
 		<graphicData>
@@ -74,7 +74,7 @@
 			<ComponentIndustrial>5</ComponentIndustrial>
 		</costList>
 		<building>
-			<turretGunDef>Gun_SPGNine</turretGunDef>
+			<turretGunDef>CE_Gun_SPGNine</turretGunDef>
 			<ai_combatDangerous>true</ai_combatDangerous>
 			<turretBurstCooldownTime>1.5</turretBurstCooldownTime>
 		</building>

--- a/1.5/Defs/ThingDefs/Emplacements_CEA/ShotgunTurret.xml
+++ b/1.5/Defs/ThingDefs/Emplacements_CEA/ShotgunTurret.xml
@@ -4,7 +4,7 @@
 	<!-- ==================== Shotgun Turret ==================== -->
 
 	<ThingDef ParentName="BaseAutoTurretGun">
-		<defName>Gun_ShotgunTurret</defName>
+		<defName>CE_Gun_ShotgunTurret</defName>
 		<label>shotgun auto-turret gun</label>
 		<graphicData>
 			<texPath>Things/Building/Security/ShotgunTurret/ShotgunTurret_gun</texPath>
@@ -42,7 +42,7 @@
 	</ThingDef>
 
 	<ThingDef ParentName="TurretAutoBase">
-		<defName>Turret_ShotgunTurret</defName>
+		<defName>CE_Turret_ShotgunTurret</defName>
 		<label>shotgun auto-turret</label>
 		<constructionSkillPrerequisite>5</constructionSkillPrerequisite>
 		<graphicData>
@@ -69,7 +69,7 @@
 		</costList>
 		<building>
 			<ai_combatDangerous>true</ai_combatDangerous>
-			<turretGunDef>Gun_ShotgunTurret</turretGunDef>
+			<turretGunDef>CE_Gun_ShotgunTurret</turretGunDef>
 			<turretBurstCooldownTime>0.5</turretBurstCooldownTime>
 		</building>
 		<designatorDropdown>CE_AutoTurrets</designatorDropdown>

--- a/1.5/Defs/ThingDefs/Emplacements_CEA/Vickers.xml
+++ b/1.5/Defs/ThingDefs/Emplacements_CEA/Vickers.xml
@@ -4,7 +4,7 @@
 	<!-- ==================== Vickers ==================== -->
 
 	<ThingDef ParentName="BaseTurretGun">
-		<defName>Gun_Vickers</defName>
+		<defName>CE_Gun_Vickers</defName>
 		<label>Vickers machine gun</label>
 		<graphicData>
 			<texPath>Things/Building/Security/Vickers/Vickers_gun</texPath>
@@ -51,7 +51,7 @@
 	</ThingDef>
 
 	<ThingDef ParentName="TurretMannedBuildableBase">
-		<defName>Turret_Vickers</defName>
+		<defName>CE_Turret_Vickers</defName>
 		<label>Vickers machine gun</label>
 		<constructionSkillPrerequisite>6</constructionSkillPrerequisite>
 		<graphicData>
@@ -74,7 +74,7 @@
 			<ComponentIndustrial>5</ComponentIndustrial>
 		</costList>
 		<building>
-			<turretGunDef>Gun_Vickers</turretGunDef>
+			<turretGunDef>CE_Gun_Vickers</turretGunDef>
 			<ai_combatDangerous>true</ai_combatDangerous>
 			<turretBurstCooldownTime>0.36</turretBurstCooldownTime>
 		</building>


### PR DESCRIPTION
## Changes

- Added the `CE_` prefix that was missing to the turrets.

## Reasoning

- Long overdue, contributes towards https://github.com/CombatExtended-Continued/CombatExtended/issues/3706

## Alternatives

- Suffering.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
