### PR TITLE
Ks-23 nerf

### DIFF
--- a/1.4/Defs/ThingDefs/Weapons_CEA_Guns/KS-23.xml
+++ b/1.4/Defs/ThingDefs/Weapons_CEA_Guns/KS-23.xml
@@ -41,7 +41,7 @@
 				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 				<hasStandardCommand>true</hasStandardCommand>
 				<defaultProjectile>Bullet_23x75mmR_Buck</defaultProjectile>
-				<warmupTime>0.6</warmupTime>
+				<warmupTime>0.9</warmupTime>
 				<range>20</range>
 				<soundCast>Shot_Shotgun</soundCast>
 				<soundCastTail>GunTail_Heavy</soundCastTail>

--- a/1.5/Defs/ThingDefs/Weapons_CEA_Guns/KS-23.xml
+++ b/1.5/Defs/ThingDefs/Weapons_CEA_Guns/KS-23.xml
@@ -41,7 +41,7 @@
 				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 				<hasStandardCommand>true</hasStandardCommand>
 				<defaultProjectile>Bullet_23x75mmR_Buck</defaultProjectile>
-				<warmupTime>0.6</warmupTime>
+				<warmupTime>0.9</warmupTime>
 				<range>20</range>
 				<soundCast>Shot_Shotgun</soundCast>
 				<soundCastTail>GunTail_Heavy</soundCastTail>

--- a/1.6/Defs/ThingDefs/Weapons_CEA_Guns/KS-23.xml
+++ b/1.6/Defs/ThingDefs/Weapons_CEA_Guns/KS-23.xml
@@ -41,7 +41,7 @@
 				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 				<hasStandardCommand>true</hasStandardCommand>
 				<defaultProjectile>Bullet_23x75mmR_Buck</defaultProjectile>
-				<warmupTime>0.6</warmupTime>
+				<warmupTime>0.9</warmupTime>
 				<range>20</range>
 				<soundCast>Shot_Shotgun</soundCast>
 				<soundCastTail>GunTail_Heavy</soundCastTail>


### PR DESCRIPTION
## Changes

Change KS-23 warmupTime to the carbine standard 0.9

## References

It is heavier and bulkier than the average shotgun

## Reasoning

A slight nerf to the KS-23 so building a normal shotgun over it has more advantages

## Alternatives

Keep the KS-23 in its current state

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
