### PR TITLE
Remove staffs from relic generation

### DIFF
--- a/1.4/Defs/ThingDefs/Weapons_CEA_Melee/Quarterstaff.xml
+++ b/1.4/Defs/ThingDefs/Weapons_CEA_Melee/Quarterstaff.xml
@@ -29,6 +29,7 @@
 		<stuffCategories>
 			<li>Woody</li>
 		</stuffCategories>
+		<relicChance>0</relicChance>
 		<tools>
 			<li Class="CombatExtended.ToolCE">
 				<label>shaft</label>

--- a/1.5/Defs/ThingDefs/Weapons_CEA_Melee/Quarterstaff.xml
+++ b/1.5/Defs/ThingDefs/Weapons_CEA_Melee/Quarterstaff.xml
@@ -29,6 +29,7 @@
 		<stuffCategories>
 			<li>Woody</li>
 		</stuffCategories>
+		<relicChance>0</relicChance>
 		<tools>
 			<li Class="CombatExtended.ToolCE">
 				<label>shaft</label>

--- a/1.6/Defs/ThingDefs/Weapons_CEA_Melee/Quarterstaff.xml
+++ b/1.6/Defs/ThingDefs/Weapons_CEA_Melee/Quarterstaff.xml
@@ -29,6 +29,7 @@
 		<stuffCategories>
 			<li>Woody</li>
 		</stuffCategories>
+		<relicChance>0</relicChance>
 		<tools>
 			<li Class="CombatExtended.ToolCE">
 				<label>shaft</label>


### PR DESCRIPTION
## Changes

- Sets the relic chance on quarterstaff to 0.

## Reasoning

- Vanilla avoids reusing the same material on multiple relics, which triggers a red error if it tries to generate a quarterstaff as a relic while already having another wooden relic.

## Alternatives

- Add metallic as a stuff option.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
