### PR TITLE
Add Manual Autoloader

### DIFF
--- a/1.6/Defs/ThingDefs/Structures_CEA/Autoloaders.xml
+++ b/1.6/Defs/ThingDefs/Structures_CEA/Autoloaders.xml
@@ -1,24 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Defs>
 
-	<ThingDef ParentName="BuildingBase">
-		<defName>CE_AutoloaderManualHiCal</defName>
-		<label>ammo crate</label>
-		<description>A versatile crate to hold ammunition belts prepared for adjacent turrets.\n\nThe colonist manning it can reload turrets directly from ammo in the crate, improving reload time keeping them out of the line of fire.</description>
+	<ThingDef ParentName="BuildingBase" Name="CEA_AutoloaderBase" Abstract="True">
 		<thingClass>CombatExtended.Building_AutoLoaderCE</thingClass>
 		<tickerType>Normal</tickerType>
 		<drawerType>MapMeshAndRealTime</drawerType>
 		<graphicData>
-			<texPath>Things/Building/Security/AutoloaderManualHiCal/AutoloaderManualHiCal_Full/AutoloaderManualHiCal_Full</texPath>
 			<graphicClass>Graphic_Multi</graphicClass>
 			<shaderType>CutoutComplex</shaderType>
-			<drawSize>(1,1)</drawSize>
 			<damageData>
 				<cornerTL>Damage/Corner</cornerTL>
 				<cornerTR>Damage/Corner</cornerTR>
 				<cornerBL>Damage/Corner</cornerBL>
 				<cornerBR>Damage/Corner</cornerBR>
 			</damageData>
+		</graphicData>
+		<altitudeLayer>Building</altitudeLayer>
+		<passability>PassThroughOnly</passability>
+		<castEdgeShadows>true</castEdgeShadows>
+		<staticSunShadowHeight>0.35</staticSunShadowHeight>
+		<hasInteractionCell>True</hasInteractionCell>
+		<interactionCellOffset>(0,0,-1)</interactionCellOffset>
+		<fillPercent>0.5</fillPercent>
+		<canOverlapZones>false</canOverlapZones>
+		<pathCost>42</pathCost>
+		<placeWorkers>
+			<li>PlaceWorker_PreventInteractionSpotOverlap</li>
+		</placeWorkers>
+		<building>
+			<destroySound>BuildingDestroyed_Metal_Small</destroySound>
+			<paintable>true</paintable>
+		</building>
+		<designationCategory>Security</designationCategory>
+		<minifiedDef>MinifiedThing</minifiedDef>
+		<thingCategories>
+			<li>BuildingsMisc</li>
+		</thingCategories>
+		<researchPrerequisites>
+			<li>Machining</li>
+		</researchPrerequisites>
+	</ThingDef>
+
+	<ThingDef ParentName="CEA_AutoloaderBase">
+		<defName>CE_AutoloaderManualHiCal</defName>
+		<label>ammo crate</label>
+		<description>A versatile crate to hold ammunition belts prepared for adjacent turrets.\n\nThe colonist manning it can reload turrets directly from ammo in the crate, improving reload time and keeping them out of the line of fire.</description>
+		<graphicData>
+			<texPath>Things/Building/Security/AutoloaderManualHiCal/AutoloaderManualHiCal_Full/AutoloaderManualHiCal_Full</texPath>
+			<drawSize>(1,1)</drawSize>
 		</graphicData>
 
 		<comps>
@@ -85,29 +114,12 @@
 				<reloadingSustainer>CE_ManualAutoloaderAmbient</reloadingSustainer>
 			</li>
 		</modExtensions>
-
-		<altitudeLayer>Building</altitudeLayer>
-		<passability>PassThroughOnly</passability>
-		<castEdgeShadows>true</castEdgeShadows>
-		<staticSunShadowHeight>0.35</staticSunShadowHeight>
-		<hasInteractionCell>True</hasInteractionCell>
-		<interactionCellOffset>(0,0,-1)</interactionCellOffset>
-		<fillPercent>0.5</fillPercent>
-		<canOverlapZones>false</canOverlapZones>
-		<pathCost>42</pathCost>
 		<size>(1,1)</size>
 		<stuffCategories>
 			<li>Metallic</li>
 			<li>Woody</li>
 		</stuffCategories>
 		<costStuffCount>55</costStuffCount>
-		<placeWorkers>
-			<li>PlaceWorker_PreventInteractionSpotOverlap</li>
-		</placeWorkers>
-		<building>
-			<destroySound>BuildingDestroyed_Metal_Small</destroySound>
-			<paintable>true</paintable>
-		</building>
 		<statBases>
 			<MaxHitPoints>100</MaxHitPoints>
 			<WorkToBuild>1800</WorkToBuild>
@@ -115,11 +127,6 @@
 			<Flammability>1</Flammability>
 			<ReloadSpeed>1</ReloadSpeed>
 		</statBases>
-		<designationCategory>Security</designationCategory>
-		<minifiedDef>MinifiedThing</minifiedDef>
-		<thingCategories>
-			<li>BuildingsMisc</li>
-		</thingCategories>
 		<researchPrerequisites>
 			<li>Machining</li>
 		</researchPrerequisites>

--- a/1.6/Defs/ThingDefs/Structures_CEA/Autoloaders.xml
+++ b/1.6/Defs/ThingDefs/Structures_CEA/Autoloaders.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Defs>
-<!--
+
 	<ThingDef ParentName="BuildingBase">
 		<defName>CE_AutoloaderManualHiCal</defName>
 		<label>ammo crate</label>
-		<description>A crate to store ammunition belts prepared for adjacent turrets. The colonist manning it can reload turrets directly from ammo in the crate, improving reload time and pawn safety.</description>
+		<description>A versatile crate to hold ammunition belts prepared for adjacent turrets.\n\nThe colonist manning it can reload turrets directly from ammo in the crate, improving reload time keeping them out of the line of fire.</description>
 		<thingClass>CombatExtended.Building_AutoLoaderCE</thingClass>
 		<tickerType>Normal</tickerType>
 		<drawerType>MapMeshAndRealTime</drawerType>
@@ -23,31 +23,20 @@
 
 		<comps>
 			<li Class="CompProperties_Forbiddable" />
-			<li Class="CombatExtended.CompProperties_AmmoUser">
-				<compClass>CombatExtended.CompAmmoListUser</compClass>
+			<li Class="CombatExtended.CompProperties_AmmoListUser">
 				<magazineSize>400</magazineSize>
 				<reloadTime>7.8</reloadTime>
 				<ammoSet>AmmoSet_762x51mmNATO</ammoSet>
 				<additionalAmmoSets>
-					<li>AmmoSet_44Magnum</li>
-					<li>AmmoSet_556x45mmNATO</li>
-					<li>AmmoSet_145x114mm</li>
+					<li>AmmoSet_RifleIntermediate</li>
+					<li>AmmoSet_Rifle</li>
+					<li>AmmoSet_AntiMateriel</li>
+					<li>AmmoSet_Shotgun</li>
+					<li>AmmoSet_Pistol</li>
 				</additionalAmmoSets>
 			</li>
 			<li Class="CompProperties_Mannable">
 				<manWorkType>Hauling</manWorkType>
-			</li>
-			<li Class="CompProperties_Explosive">
-				<explosiveRadius>0.9</explosiveRadius>
-				<explosiveDamageType>Bomb</explosiveDamageType>
-				<startWickOnDamageTaken>
-					<li>Bomb</li>
-					<li>Flame</li>
-				</startWickOnDamageTaken>
-				<startWickHitPointsPercent>0.5</startWickHitPointsPercent>
-				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-				<explodeOnKilled>True</explodeOnKilled>
-				<wickTicks>60~90</wickTicks>
 			</li>
 		</comps>
 
@@ -91,11 +80,12 @@
 					</damageData>
 				</emptyGraphic>
 				<allowedTurretTags>
-					<li>CE_TurretHeavy</li>
+				<!--	<li>CE_TurretHeavy</li> -->
 				</allowedTurretTags>
 				<reloadingSustainer>CE_ManualAutoloaderAmbient</reloadingSustainer>
 			</li>
 		</modExtensions>
+
 		<altitudeLayer>Building</altitudeLayer>
 		<passability>PassThroughOnly</passability>
 		<castEdgeShadows>true</castEdgeShadows>
@@ -154,5 +144,5 @@
 			</li>
 		</subSounds>
 	</SoundDef>
--->
+
 </Defs>

--- a/About/About.xml
+++ b/About/About.xml
@@ -3,7 +3,7 @@
 	<name>Combat Extended Armory</name>
 	<author>CE Team</author>
 	<url>https://github.com/CombatExtended-Continued/CombatExtendedArmory</url>
-	<description>Version: 16.2.1.0\n\nAdds a variety of new weapons, apparel, and other equipment to utilize CE mechanics.</description>
+	<description>Version: 16.2.1.1\n\nAdds a variety of new weapons, apparel, and other equipment to utilize CE mechanics.</description>
 	<modIconPath IgnoreIfNoMatchingField="True">UI/Icons/CE_ModIcon_JustHat</modIconPath>	
 	<supportedVersions>
 		<li>1.4</li>


### PR DESCRIPTION
## Additions
- Adds a basic manual autoloader capable of feeding pistol, shotgun, rifle (standard and intermediate), and anti-material rifle ammo. This will cover basic needs.

## Changes
- Increments the mod version number.

## Reasoning
- A good starting point for autoloader implementation, which we can expand upon with more specialized or more capable autoloaders in the future.
- Set `AmmoSet_762x51mmNATO` as the base ammoSet, because if a generic ammoset is used, it will use the generic label even in regular ammo mode, which can be confusing.

## Alternatives
- Could use a different set of calibers.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
