### PR TITLE
Smoke Bomb Rework/Buff

### DIFF
--- a/1.5/Defs/ThingDefs/Weapons_CEA_Grenades/Smoke_Bomb.xml
+++ b/1.5/Defs/ThingDefs/Weapons_CEA_Grenades/Smoke_Bomb.xml
@@ -26,7 +26,7 @@
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
 				<damageAmountBase>4</damageAmountBase>
 				<explosiveDamageType>Stun</explosiveDamageType>
-				<explosiveRadius>0.01</explosiveRadius>
+				<explosiveRadius>0.1</explosiveRadius>
 				<applyDamageToExplosionCellsNeighbors>false</applyDamageToExplosionCellsNeighbors>
 			</li>
 		</comps>
@@ -78,7 +78,7 @@
 		</verbs>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>3</damageAmountBase>
+				<damageAmountBase>2</damageAmountBase>
 				<explosiveDamageType>Smoke</explosiveDamageType>
 				<postExplosionGasType>BlindSmoke</postExplosionGasType>
 				<preExplosionSpawnChance>1</preExplosionSpawnChance>
@@ -117,7 +117,7 @@
 		</ingredients>
 		<fixedIngredientFilter>
 			<thingDefs>
-				<li>WoodLog</li>			
+				<li>WoodLog</li>
 				<li>Prometheum</li>
 			</thingDefs>
 		</fixedIngredientFilter>

--- a/1.5/Defs/ThingDefs/Weapons_CEA_Grenades/Smoke_Bomb.xml
+++ b/1.5/Defs/ThingDefs/Weapons_CEA_Grenades/Smoke_Bomb.xml
@@ -24,9 +24,9 @@
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>1</damageAmountBase>
+				<damageAmountBase>4</damageAmountBase>
 				<explosiveDamageType>Stun</explosiveDamageType>
-				<explosiveRadius>0.1</explosiveRadius>
+				<explosiveRadius>0.01</explosiveRadius>
 				<applyDamageToExplosionCellsNeighbors>false</applyDamageToExplosionCellsNeighbors>
 			</li>
 		</comps>
@@ -36,25 +36,23 @@
 		<defName>CE_Weapon_SmokeBomb</defName>
 		<equipmentType>Primary</equipmentType>
 		<label>smoke bomb</label>
-		<description>A primative smoke bomb that releases a small cloud of smokescreen, providing concealment against gunfire. Will stun for a brief moment on a direct hit.</description>
+		<description>Instantly releases a small cloud of defensive smoke, providing concealment against gunfire. Will stun on a direct hit.</description>
 		<graphicData>
 			<texPath>Things/Weapons/SmokeBomb</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<soundInteract>Interact_Grenade</soundInteract>
 		<techLevel>Neolithic</techLevel>
-		<generateAllowChance>0.50</generateAllowChance>
-		<stackLimit>25</stackLimit>
+		<stackLimit>50</stackLimit>
 		<statBases>
 			<Mass>0.30</Mass>
 			<Bulk>0.50</Bulk>
-			<MarketValue>9.15</MarketValue>
 			<SightsEfficiency>1.0</SightsEfficiency>
 			<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 		</statBases>
 		<weaponTags>
 			<li>CE_AI_SMOKE</li>
-			<li>GrenadeSmoke</li>
+			<li>CE_GrenadeNeolithic_Smoke</li>
 			<li>CE_OneHandedWeapon</li>
 		</weaponTags>
 		<thingCategories>
@@ -103,10 +101,10 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>Cloth</li>
+						<li>WoodLog</li>
 					</thingDefs>
 				</filter>
-				<count>10</count>
+				<count>15</count>
 			</li>
 			<li>
 				<filter>
@@ -116,20 +114,11 @@
 				</filter>
 				<count>2</count>
 			</li>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>WoodLog</li>
-					</thingDefs>
-				</filter>
-				<count>5</count>
-			</li>
 		</ingredients>
 		<fixedIngredientFilter>
 			<thingDefs>
-				<li>Cloth</li>
+				<li>WoodLog</li>			
 				<li>Prometheum</li>
-				<li>WoodLog</li>
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>

--- a/1.6/Defs/ThingDefs/Weapons_CEA_Grenades/Smoke_Bomb.xml
+++ b/1.6/Defs/ThingDefs/Weapons_CEA_Grenades/Smoke_Bomb.xml
@@ -26,7 +26,7 @@
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
 				<damageAmountBase>4</damageAmountBase>
 				<explosiveDamageType>Stun</explosiveDamageType>
-				<explosiveRadius>0.01</explosiveRadius>
+				<explosiveRadius>0.1</explosiveRadius>
 				<applyDamageToExplosionCellsNeighbors>false</applyDamageToExplosionCellsNeighbors>
 			</li>
 		</comps>
@@ -78,7 +78,7 @@
 		</verbs>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>3</damageAmountBase>
+				<damageAmountBase>2</damageAmountBase>
 				<explosiveDamageType>Smoke</explosiveDamageType>
 				<postExplosionGasType>BlindSmoke</postExplosionGasType>
 				<preExplosionSpawnChance>1</preExplosionSpawnChance>
@@ -117,7 +117,7 @@
 		</ingredients>
 		<fixedIngredientFilter>
 			<thingDefs>
-				<li>WoodLog</li>			
+				<li>WoodLog</li>
 				<li>Prometheum</li>
 			</thingDefs>
 		</fixedIngredientFilter>

--- a/1.6/Defs/ThingDefs/Weapons_CEA_Grenades/Smoke_Bomb.xml
+++ b/1.6/Defs/ThingDefs/Weapons_CEA_Grenades/Smoke_Bomb.xml
@@ -24,9 +24,9 @@
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>1</damageAmountBase>
+				<damageAmountBase>5</damageAmountBase>
 				<explosiveDamageType>Stun</explosiveDamageType>
-				<explosiveRadius>0.1</explosiveRadius>
+				<explosiveRadius>0.01</explosiveRadius>
 				<applyDamageToExplosionCellsNeighbors>false</applyDamageToExplosionCellsNeighbors>
 			</li>
 		</comps>
@@ -36,7 +36,7 @@
 		<defName>CE_Weapon_SmokeBomb</defName>
 		<equipmentType>Primary</equipmentType>
 		<label>smoke bomb</label>
-		<description>A primative smoke bomb that releases a small cloud of smokescreen, providing concealment against gunfire. Will stun for a brief moment on a direct hit.</description>
+		<description>Instantly releases a small cloud of defensive smoke, providing concealment against gunfire. Will stun on a direct hit.</description>
 		<graphicData>
 			<texPath>Things/Weapons/SmokeBomb</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -54,7 +54,7 @@
 		</statBases>
 		<weaponTags>
 			<li>CE_AI_SMOKE</li>
-			<li>GrenadeSmoke</li>
+			<li>CE_GrenadeNeolithic_Smoke</li>
 			<li>CE_OneHandedWeapon</li>
 		</weaponTags>
 		<thingCategories>

--- a/1.6/Defs/ThingDefs/Weapons_CEA_Grenades/Smoke_Bomb.xml
+++ b/1.6/Defs/ThingDefs/Weapons_CEA_Grenades/Smoke_Bomb.xml
@@ -24,7 +24,7 @@
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>5</damageAmountBase>
+				<damageAmountBase>4</damageAmountBase>
 				<explosiveDamageType>Stun</explosiveDamageType>
 				<explosiveRadius>0.01</explosiveRadius>
 				<applyDamageToExplosionCellsNeighbors>false</applyDamageToExplosionCellsNeighbors>
@@ -43,12 +43,10 @@
 		</graphicData>
 		<soundInteract>Interact_Grenade</soundInteract>
 		<techLevel>Neolithic</techLevel>
-		<generateAllowChance>0.50</generateAllowChance>
-		<stackLimit>25</stackLimit>
+		<stackLimit>50</stackLimit>
 		<statBases>
 			<Mass>0.30</Mass>
 			<Bulk>0.50</Bulk>
-			<MarketValue>9.15</MarketValue>
 			<SightsEfficiency>1.0</SightsEfficiency>
 			<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 		</statBases>
@@ -103,10 +101,10 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>Cloth</li>
+						<li>WoodLog</li>
 					</thingDefs>
 				</filter>
-				<count>10</count>
+				<count>15</count>
 			</li>
 			<li>
 				<filter>
@@ -116,20 +114,11 @@
 				</filter>
 				<count>2</count>
 			</li>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>WoodLog</li>
-					</thingDefs>
-				</filter>
-				<count>5</count>
-			</li>
 		</ingredients>
 		<fixedIngredientFilter>
 			<thingDefs>
-				<li>Cloth</li>
+				<li>WoodLog</li>			
 				<li>Prometheum</li>
-				<li>WoodLog</li>
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>


### PR DESCRIPTION
## Additions
-Removed industrial spawn tag and added tribal spawn tags 
-Buffed stun to 2~ seconds
-Removed cloth build cost, replaced with more wood. Smoke bomb is made from flash paper, not cloth

-General updates 

## Reasoning

-Update to use new tags CE added for tribals
-Tribal colonist can stun big mechs and enemies, then have another bomb them 

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
Note; Every tribal colony I have every played for the past 2 years has used a similar balanced smoke     
